### PR TITLE
Add minority-report and create-blacklist subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+ - `minority-report` subcommand — computes minority base frequency distribution from a pre-computed `samtools mpileup` file (`.mpileup` or `.mpileup.gz`), with optional blacklist filtering
+ - `create-blacklist` subcommand — runs mpileup and minority base distribution across a set of BAM files, then aggregates per-position frequencies to produce a minority variant blacklist TSV
+
 ### Fixed
 
 ### Changed

--- a/docs/source/usage/pipeline-processes.md
+++ b/docs/source/usage/pipeline-processes.md
@@ -153,6 +153,76 @@ jasentool annotate-delly \
   -o delly_annotated.vcf
 ```
 
+## create-blacklist
+
+Build a minority variant blacklist by running `samtools mpileup` and minority base distribution
+analysis across a set of BAM files, then aggregating positions that exceed a frequency threshold
+in enough samples. The resulting TSV can be passed to `minority-report` via `--blacklist` to
+exclude known high-noise positions.
+
+Intermediate per-sample mpileup and distribution files are written to `--output-dir`. Only
+samples whose stem matches `--sample-pattern` contribute to the final blacklist.
+
+```
+jasentool create-blacklist (--input-file <FILE> | --input-dir <DIR>)
+                            --output-dir <DIR> -o <FILE>
+                            [--bed-file <FILE>] [--samtools <PATH>]
+                            [--sample-pattern <REGEX>]
+                            [--min-freq <FLOAT>] [--min-count <INT>]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `-i`/`--input-file` | Yes (or `--input-dir`) | — | Text file of BAM paths, one per line |
+| `--input-dir` | Yes (or `--input-file`) | — | Directory containing `*.bam` files |
+| `--output-dir` | Yes | — | Directory for intermediate files |
+| `-o`/`--output-file` | Yes | — | Output blacklist TSV path |
+| `--bed-file` | No | — | BED file passed to `samtools mpileup -l` |
+| `--samtools` | No | `samtools` | Path or name of the samtools executable |
+| `--sample-pattern` | No | `.*` | Regex to filter which sample names contribute to the blacklist |
+| `--min-freq` | No | `0.05` | Minimum minority frequency to count a position |
+| `--min-count` | No | `5` | Minimum number of samples a position must appear in |
+
+**Example**
+
+```bash
+# From a directory of BAM files, only including samples matching ^[0-9]{2}MT
+jasentool create-blacklist \
+  --input-dir /data/bams \
+  --output-dir /data/blacklist_work \
+  -o blacklist.tsv \
+  --bed-file targets.bed \
+  --sample-pattern '^[0-9]{2}MT'
+```
+
+## minority-report
+
+Compute minority base frequency distribution from a pre-computed `samtools mpileup` file. For each
+position with coverage between 30 and 100, the second-highest base count divided by coverage is
+recorded as the minority frequency. Outputs two files:
+
+- `<output>` — one minority frequency per line (no position)
+- `<output>.withpos` — tab-separated `position\tminority_freq`
+
+```
+jasentool minority-report --mpileup <FILE> -o <OUTPUT_STEM> [--blacklist <FILE>]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--mpileup` | Yes | — | Input mpileup file (`.mpileup` or `.mpileup.gz`) |
+| `-o`/`--output` | Yes | — | Output path stem (no extension) |
+| `--blacklist` | No | — | Blacklist TSV of positions to exclude (see `create-blacklist`) |
+
+**Example**
+
+```bash
+jasentool minority-report \
+  --mpileup sample.mpileup.gz \
+  --blacklist blacklist.tsv \
+  -o sample_minority_dist
+```
+
 ## post-align-qc
 
 ```

--- a/jasentool/cli.py
+++ b/jasentool/cli.py
@@ -293,6 +293,51 @@ def create_yaml_cmd(amrfinder, bam, bai, chewbbaca, emmtyper, gambitcore, groups
     _parser().create_yaml(options)
 
 
+@cli.command('minority-report')
+@click.option('--mpileup', required=True, type=click.Path(exists=True),
+              help='Input mpileup file (.mpileup or .mpileup.gz)')
+@click.option('--blacklist', default=None, type=click.Path(exists=True),
+              help='Optional blacklist TSV file of positions to exclude')
+@click.option('-o', '--output', required=True, help='Output path stem (no extension)')
+def minority_report_cmd(mpileup, blacklist, output):
+    """Compute minority base frequency distribution from a samtools mpileup file."""
+    options = types.SimpleNamespace(mpileup=mpileup, blacklist=blacklist, output=output)
+    _parser().minority_report(options)
+
+
+@cli.command('create-blacklist')
+@click.option('-i', '--input-file', default=None,
+              help='Text file containing BAM file paths (one per line)')
+@click.option('--input-dir', default=None,
+              help='Directory containing *.bam files')
+@click.option('--output-dir', required=True, help='Directory for intermediate files')
+@click.option('-o', '--output-file', required=True, help='Path to the output blacklist TSV')
+@click.option('--bed-file', default=None, type=click.Path(exists=True),
+              help='BED file passed to samtools mpileup -l')
+@click.option('--samtools', default='samtools', show_default=True,
+              help='Path or name of the samtools executable')
+@click.option('--sample-pattern', default='.*', show_default=True,
+              help='Regex to filter sample names included in blacklist aggregation')
+@click.option('--min-freq', default=0.05, show_default=True, type=float,
+              help='Minimum minority frequency to count a position')
+@click.option('--min-count', default=5, show_default=True, type=int,
+              help='Minimum number of samples a position must appear in to enter the blacklist')
+def create_blacklist_cmd(input_file, input_dir, output_dir, output_file,
+                         bed_file, samtools, sample_pattern, min_freq, min_count):
+    """Create a minority variant blacklist from a set of BAM files."""
+    if not input_file and not input_dir:
+        raise click.UsageError("One of --input-file or --input-dir is required.")
+    if input_file and input_dir:
+        raise click.UsageError("--input-file and --input-dir are mutually exclusive.")
+    options = types.SimpleNamespace(
+        input_file=input_file, input_dir=input_dir,
+        output_dir=output_dir, output_file=output_file,
+        bed_file=bed_file, samtools=samtools,
+        sample_pattern=sample_pattern, min_freq=min_freq, min_count=min_count,
+    )
+    _parser().create_blacklist(options)
+
+
 @cli.command('annotate-delly')
 @click.option('-v', '--vcf', required=True, type=click.Path(exists=True, path_type=Path),
               help='Delly VCF/BCF to annotate')

--- a/jasentool/create_blacklist.py
+++ b/jasentool/create_blacklist.py
@@ -1,0 +1,92 @@
+"""Module for creating a minority variant blacklist from a set of BAM files"""
+
+import re
+import subprocess
+from pathlib import Path
+
+from jasentool.minority_report import MinorityReport
+from jasentool.log import get_logger
+
+logger = get_logger(__name__)
+
+
+class CreateBlacklist:
+    """Create a minority variant blacklist by aggregating per-sample minority distributions."""
+
+    def __init__(self, samtools='samtools'):
+        self.samtools = samtools
+        self.reporter = MinorityReport()
+
+    def _get_bam_files(self, bam_input_file, input_dir):
+        """Return a list of BAM paths from a text file of paths or a directory."""
+        if bam_input_file:
+            bam_files = []
+            with open(bam_input_file, 'r', encoding='utf-8') as fh:
+                for line in fh:
+                    path = line.strip()
+                    if path:
+                        bam_files.append(Path(path))
+            return bam_files
+        if input_dir:
+            return sorted(Path(input_dir).glob('*.bam'))
+        return []
+
+    def _run_mpileup(self, bam_path, out_mpileup, bed_file=None):
+        """Run samtools mpileup on a BAM file."""
+        cmd = [self.samtools, 'mpileup', str(bam_path), '-o', str(out_mpileup)]
+        if bed_file:
+            cmd += ['-l', str(bed_file)]
+        subprocess.check_call(cmd)
+
+    def run(self, bam_input_file, input_dir, output_dir, output_file,
+            bed_file=None, min_freq=0.05, min_count=5, sample_pattern='.*'):
+        """
+        For each BAM file: run mpileup and compute minority base distribution.
+        Aggregate .withpos files across samples to produce a blacklist TSV.
+
+        Only samples whose stem matches `sample_pattern` contribute to the
+        blacklist aggregation (default: all samples).
+        """
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        bam_files = self._get_bam_files(bam_input_file, input_dir)
+        if not bam_files:
+            raise FileNotFoundError('No BAM files found in the specified input.')
+
+        pattern = re.compile(sample_pattern)
+        withpos_files = []
+
+        for bam in bam_files:
+            sample_name = bam.stem
+            mpileup_path = output_dir / f"{sample_name}.mpileup"
+            dist_path = output_dir / f"{sample_name}_minority_dist"
+
+            logger.info("Running mpileup for %s", sample_name)
+            self._run_mpileup(bam, mpileup_path, bed_file)
+
+            logger.info("Computing minority distribution for %s", sample_name)
+            _, withpos_path = self.reporter.minority_base_distribution(mpileup_path, dist_path)
+
+            if pattern.search(sample_name):
+                withpos_files.append(withpos_path)
+            else:
+                logger.debug("Skipping %s (does not match sample_pattern)", sample_name)
+
+        pos_counts = {}
+        for withpos in withpos_files:
+            with open(withpos, 'r', encoding='utf-8') as fh:
+                for line in fh:
+                    parts = line.strip().split('\t')
+                    if len(parts) < 2:
+                        continue
+                    pos, freq = parts[0], float(parts[1])
+                    if freq > min_freq:
+                        pos_counts[pos] = pos_counts.get(pos, 0) + 1
+
+        with open(output_file, 'w', encoding='utf-8') as fout:
+            for pos, count in pos_counts.items():
+                if count >= min_count:
+                    fout.write(f"{pos}\t{count}\n")
+
+        logger.info("Wrote blacklist to %s", output_file)

--- a/jasentool/main.py
+++ b/jasentool/main.py
@@ -20,6 +20,8 @@ from jasentool.bigsdb import BIGSdb
 from jasentool.concatenate import Concatenate
 from jasentool.create_yaml import CreateYaml
 from jasentool.annotate_delly import AnnotateDelly
+from jasentool.minority_report import MinorityReport
+from jasentool.create_blacklist import CreateBlacklist
 from jasentool.log import get_logger
 
 logger = get_logger(__name__)
@@ -172,6 +174,19 @@ class OptionsParser:
     def create_yaml(self, options):
         """Create YAML input file for Bonsai upload"""
         CreateYaml().run(options)
+
+    def minority_report(self, options):
+        """Compute minority base distribution from a pre-computed mpileup file."""
+        MinorityReport().run(options.mpileup, options.output, options.blacklist)
+
+    def create_blacklist(self, options):
+        """Create a minority variant blacklist from a set of BAM files."""
+        CreateBlacklist(samtools=options.samtools).run(
+            options.input_file, options.input_dir,
+            options.output_dir, options.output_file,
+            options.bed_file, options.min_freq, options.min_count,
+            options.sample_pattern,
+        )
 
     def annotate_delly(self, options):
         """Annotate Delly SV VCF with gene/locus_tag from a tabix BED."""

--- a/jasentool/minority_report.py
+++ b/jasentool/minority_report.py
@@ -1,0 +1,99 @@
+"""Module for minority base distribution analysis from mpileup data"""
+
+import re
+import gzip
+from pathlib import Path
+
+from jasentool.log import get_logger
+
+logger = get_logger(__name__)
+
+
+def read_blacklist(filepath):
+    """Read a blacklist TSV file and return a set of blacklisted positions."""
+    blacklisted = set()
+    with open(filepath, 'r', encoding='utf-8') as fh:
+        for line in fh:
+            data = line.strip().split('\t')
+            if data:
+                blacklisted.add(data[0])
+    return blacklisted
+
+
+def parse_pile(reads, ref):
+    """Parse a mpileup read column and return per-base counts."""
+    counts = {'A': 0, 'T': 0, 'C': 0, 'G': 0, 'N': 0}
+    i = 0
+    while i < len(reads):
+        if reads[i] in "ACGTNacgtn":
+            counts[reads[i].upper()] += 1
+            i += 1
+        elif reads[i] in ',.':
+            counts[ref.upper()] += 1
+            i += 1
+        elif reads[i] in '$*':
+            i += 1
+        elif reads[i] == '^':
+            i += 2  # '^' is followed by exactly one mapping-quality char
+        elif reads[i] in '+-':
+            match = re.findall(r'[+-](\d+)[ACGTNacgtn*]+', reads[i:])
+            if match:
+                digit = match[0]
+                i += 1 + len(digit) + int(digit)
+            else:
+                i += 1
+        else:
+            logger.warning('mpileup parser: unknown char %r in %s[%d]', reads[i], reads, i)
+            i += 1
+    return counts
+
+
+class MinorityReport:
+    """Compute minority base distributions from samtools mpileup output."""
+
+    def minority_base_distribution(self, mpileup_path, out_path, blacklist=None):
+        """
+        Parse a mpileup file and write minority base frequency files.
+
+        Produces two output files:
+          - <out_path>          : one minority frequency per line (no position)
+          - <out_path>.withpos  : tab-separated position and minority frequency
+        """
+        if blacklist is None:
+            blacklist = set()
+
+        mpileup_path = Path(mpileup_path)
+        out_path = Path(out_path)
+        withpos_path = Path(str(out_path) + '.withpos')
+
+        open_fn = gzip.open if mpileup_path.suffix == '.gz' else open
+
+        with open_fn(mpileup_path, 'rt', encoding='utf-8') as fin, \
+             open(out_path, 'w', encoding='utf-8') as fout, \
+             open(withpos_path, 'w', encoding='utf-8') as fout_pos:
+            for line in fin:
+                data = line.strip().split('\t')
+                if len(data) < 6:
+                    continue
+                if data[1] in blacklist:
+                    continue
+                cov = int(data[3])
+                if 30 < cov < 100:
+                    ref = data[2].upper()
+                    types = parse_pile(data[4], ref)
+                    minority_freq = sorted(
+                        [types['A'], types['G'], types['C'], types['T']]
+                    )[2] / cov
+                    if minority_freq > 0:
+                        fout_pos.write(f"{data[1]}\t{minority_freq}\n")
+                        fout.write(f"{minority_freq}\n")
+
+        logger.info("Wrote minority distribution to %s and %s", out_path, withpos_path)
+        return out_path, withpos_path
+
+    def run(self, mpileup_path, out_path, blacklist_path=None):
+        """Run minority base distribution on a pre-computed mpileup file."""
+        blacklist = set()
+        if blacklist_path:
+            blacklist = read_blacklist(blacklist_path)
+        return self.minority_base_distribution(mpileup_path, out_path, blacklist)


### PR DESCRIPTION
The following changes were made:
 - `minority-report` subcommand — computes minority base frequency distribution from a pre-computed `samtools mpileup` file (`.mpileup` or `.mpileup.gz`), with optional blacklist filtering
 - `create-blacklist` subcommand — runs mpileup and minority base distribution across a set of BAM files, then aggregates per-position frequencies to produce a minority variant blacklist TSV