### PR TITLE
Update jasentool to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [1.2.0]
+
+### Added
+
  - `check-backup` subcommand — cross-checks Bonsai samples against the on-disk backup storage tree per JASEN profile. Emits a per-sample summary, a per-missing-file detail CSV, and a per-output stats CSV.
  - `--check-orphans` flag on `check-backup` — reverse check that lists backup files which don't match any expected sample × output.
  - `-v`/`--verbose` flag on `reformat-csv` and `create-blacklist`.

--- a/jasentool/__version__.py
+++ b/jasentool/__version__.py
@@ -1,3 +1,3 @@
 """Jasentool version"""
 
-VERSION = "1.1.0"
+VERSION = "1.2.0"


### PR DESCRIPTION
Bumps `jasentool/__version__.py` from 1.1.0 to 1.2.0.

Separate, single-file version bump following the create-yaml (#43) and check-backup (#50) merges. The release workflows read this version, so publishing a GitHub release `v1.2.0` after this lands will build/push PyPI + `clinicalgenomicslund/jasentool:1.2.0` + `:latest`.